### PR TITLE
peer_filter() -type is incomplete - ERL-1191

### DIFF
--- a/lib/diameter/src/base/diameter.erl
+++ b/lib/diameter/src/base/diameter.erl
@@ -306,7 +306,8 @@ call(SvcName, App, Message) ->
     | {eval, eval()}
     | {neg, peer_filter()}
     | {all, [peer_filter()]}
-    | {any, [peer_filter()]}.
+    | {any, [peer_filter()]}
+    | {first, [peer_filter()]}.
 
 -opaque peer_ref()
    :: pid().


### PR DESCRIPTION
Given http://erlang.org/doc/man/diameter.html#peer_filter a possible peer_filter() could be
{first, [[peer_filter()]]} which is missing in the base/diameter.erl module.
 This missing -type makes dialyzer raise a (no local return) warning in the diameter call when I try to pass a filter with the "first" inside the call options in a diameter:call/4.